### PR TITLE
adds file list widget viewer, stub for editor

### DIFF
--- a/arches_component_lab/src/arches_component_lab/widgets/FileListWidget/FileListWidget.vue
+++ b/arches_component_lab/src/arches_component_lab/widgets/FileListWidget/FileListWidget.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+import { onMounted, ref } from "vue";
+
+import Message from "primevue/message";
+import ProgressSpinner from "primevue/progressspinner";
+
+import FileListWidgetViewer from "@/arches_component_lab/widgets/FileListWidget/components/FileListWidgetViewer.vue";
+
+import {
+    fetchWidgetData,
+    fetchNodeData,
+} from "@/arches_component_lab/widgets/api.ts";
+import { EDIT, VIEW } from "@/arches_component_lab/widgets/constants.ts";
+
+import type {
+    WidgetMode,
+    FileReference,
+} from "@/arches_component_lab/widgets/types.ts";
+
+const props = defineProps<{
+    mode: WidgetMode;
+    initialValue: FileReference[] | null | undefined;
+    nodeAlias: string;
+    graphSlug: string;
+    showLabel?: boolean;
+}>();
+
+const isLoading = ref(true);
+const nodeData = ref();
+const widgetData = ref();
+const configurationError = ref();
+
+onMounted(async () => {
+    try {
+        widgetData.value = await fetchWidgetData(
+            props.graphSlug,
+            props.nodeAlias,
+        );
+        nodeData.value = await fetchNodeData(props.graphSlug, props.nodeAlias);
+    } catch (error) {
+        configurationError.value = error;
+    } finally {
+        isLoading.value = false;
+    }
+});
+</script>
+
+<template>
+    <ProgressSpinner
+        v-if="isLoading"
+        style="width: 2em; height: 2em"
+    />
+    <Message
+        v-else-if="configurationError"
+        severity="error"
+        size="small"
+    >
+        {{ configurationError.message }}
+    </Message>
+    <template v-else>
+        <label v-if="props.showLabel">
+            <span>{{ widgetData.label }}</span>
+            <span v-if="nodeData.isrequired && props.mode === EDIT">*</span>
+        </label>
+
+        <div v-if="mode === EDIT"></div>
+        <div v-if="mode === VIEW">
+            <FileListWidgetViewer
+                :value="initialValue"
+                :widget-data="widgetData"
+            />
+        </div>
+    </template>
+</template>

--- a/arches_component_lab/src/arches_component_lab/widgets/FileListWidget/components/FileListWidgetViewer.vue
+++ b/arches_component_lab/src/arches_component_lab/widgets/FileListWidget/components/FileListWidgetViewer.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { Image, Galleria } from "primevue";
+import type { FileReference } from "@/arches_component_lab/widgets/types.ts";
+
+const props = defineProps<{
+    value: FileReference[] | null | undefined;
+    widgetData: {
+        config: object;
+    };
+}>();
+
+const imageData = computed(() => {
+    return props.value?.map((fileReference) => {
+        return {
+            thumbnailImageSrc: `${fileReference.url}`,
+            itemImageSrc: `${fileReference.url}`,
+            alt: fileReference.altText,
+            title: fileReference.title,
+        };
+    });
+});
+
+const showThumbnails = computed(() => {
+    return imageData.value && imageData.value.length > 1;
+});
+</script>
+
+<template>
+    <Galleria
+        :value="imageData"
+        :show-thumbnails="showThumbnails"
+    >
+        <template #item="slotProps">
+            <Image
+                class="mainImage"
+                :src="slotProps.item.itemImageSrc"
+                :alt="slotProps.item.alt"
+            />
+        </template>
+        <template
+            v-if="showThumbnails"
+            #thumbnail="slotProps"
+        >
+            <Image
+                class="thumbnailImage"
+                :src="slotProps.item.itemImageSrc"
+                :alt="slotProps.item.alt"
+            />
+        </template>
+    </Galleria>
+</template>
+
+<style scoped>
+:deep(.mainImage) {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+:deep(.mainImage img) {
+    max-width: 100%;
+}
+
+:deep(.thumbnailImage img) {
+    max-height: 5rem;
+}
+</style>

--- a/arches_component_lab/src/arches_component_lab/widgets/types.ts
+++ b/arches_component_lab/src/arches_component_lab/widgets/types.ts
@@ -24,3 +24,23 @@ export interface ResourceInstanceResult {
     resourceinstanceid: string;
     display_value: string;
 }
+
+export interface FileReference {
+    url: string;
+    name: string;
+    path: string;
+    size: number;
+    type: string;
+    index: number;
+    width: number;
+    height: number;
+    status: string;
+    content: string;
+    file_id: string;
+    accepted: boolean;
+    lastModified: number;
+    altText: string;
+    attribution: string;
+    description: string;
+    title: string;
+}


### PR DESCRIPTION
Adds file list widget viewer with a galleria for viewing images.  Currently assumes only images are in the file list widget viewer.  Yanks chrome/navigation when there's only a single image.