### PR TITLE
Simplify node and widget views

### DIFF
--- a/arches_component_lab/views/api/widgets.py
+++ b/arches_component_lab/views/api/widgets.py
@@ -1,5 +1,4 @@
 from django.db.models import Q
-from django.utils import translation
 from django.views.generic import View
 
 from arches import VERSION as arches_version
@@ -7,22 +6,6 @@ from arches.app.models import models
 from arches.app.utils.betterJSONSerializer import JSONDeserializer, JSONSerializer
 from arches.app.utils.response import JSONResponse
 from arches.app.datatypes.datatypes import DataTypeFactory
-
-
-def update_i18n_properties(response):
-    user_language = translation.get_language()
-    config = response["config"]
-
-    if "i18n_properties" in config and isinstance(config["i18n_properties"], list):
-        for prop in config["i18n_properties"]:
-            if (
-                prop in config
-                and isinstance(config[prop], dict)
-                and user_language in config[prop]
-            ):
-                config[prop] = config[prop][user_language]
-    response["config"] = config
-    return response
 
 
 class WidgetDataView(View):
@@ -58,23 +41,23 @@ class WidgetDataView(View):
                 config=default_widget.defaultconfig,
             )
 
-        response = update_i18n_properties(
-            JSONDeserializer().deserialize(
-                JSONSerializer().serialize(card_x_node_x_widget)
-            )
+        card_x_node_x_widget_dict = JSONDeserializer().deserialize(
+            JSONSerializer().serialize(card_x_node_x_widget)
         )
 
         datatype = DataTypeFactory().get_instance(card_x_node_x_widget.node.datatype)
         # When dropping support for v7.6, try/except can be removed
         try:
-            response["config"]["defaultValue"] = datatype.get_interchange_value(
-                response["config"].get("defaultValue", None)
+            card_x_node_x_widget_dict["config"]["defaultValue"] = (
+                datatype.get_interchange_value(
+                    card_x_node_x_widget_dict["config"].get("defaultValue", None)
+                )
             )
         except AttributeError:
             # Handle the case where the datatype does not have a get_interchange_value method
             pass
 
-        return JSONResponse(response)
+        return JSONResponse(card_x_node_x_widget_dict)
 
 
 class NodeDataView(View):
@@ -89,8 +72,4 @@ class NodeDataView(View):
             )
         node = models.Node.objects.get(node_filter)
 
-        response = update_i18n_properties(
-            JSONDeserializer().deserialize(JSONSerializer().serialize(node))
-        )
-
-        return JSONResponse(response)
+        return JSONResponse(node)


### PR DESCRIPTION
I get the same response when I delete this helper, because JSONSerializer [already handles for i18n props](https://github.com/archesproject/arches/blob/bad49eb22b4443124da58b6464fd1c3ff9d91b2c/arches/app/utils/betterJSONSerializer.py#L134-L136).

