### PR TITLE
Supply missing widget configs #33

### DIFF
--- a/arches_component_lab/views/api/widgets.py
+++ b/arches_component_lab/views/api/widgets.py
@@ -1,10 +1,10 @@
-from arches.app.utils.betterJSONSerializer import JSONDeserializer, JSONSerializer
+from django.db.models import Q
 from django.utils import translation
 from django.views.generic import View
 
 from arches import VERSION as arches_version
-from django.db.models import Q
 from arches.app.models import models
+from arches.app.utils.betterJSONSerializer import JSONDeserializer, JSONSerializer
 from arches.app.utils.response import JSONResponse
 from arches.app.datatypes.datatypes import DataTypeFactory
 
@@ -36,9 +36,27 @@ class WidgetDataView(View):
                 node__source_identifier_id__isnull=True,
             )
 
-        card_x_node_x_widget = models.CardXNodeXWidget.objects.select_related(
-            "node"
-        ).get(query_filter)
+        card_x_node_x_widget = (
+            models.CardXNodeXWidget.objects.select_related("node")
+            .filter(query_filter)
+            .first()
+        )
+
+        if not card_x_node_x_widget:
+            # Supply default widget configuration.
+            nodes = models.Node.objects.filter(graph__slug=graph_slug, alias=node_alias)
+            if arches_version >= (8, 0):
+                nodes = nodes.filter(source_identifier=None)
+            node = nodes.get()
+            datatype_factory = DataTypeFactory()
+            d_data_type = datatype_factory.datatypes[node.datatype]
+            default_widget = d_data_type.defaultwidget
+            card_x_node_x_widget = models.CardXNodeXWidget(
+                node=node,
+                card=node.nodegroup.cardmodel_set.first(),
+                widget=default_widget,
+                config=default_widget.defaultconfig,
+            )
 
         response = update_i18n_properties(
             JSONDeserializer().deserialize(


### PR DESCRIPTION
Closes #33 

Unless & until core arches makes CardXNodeXWidget fully one-to-one with Node, maintain the status quo in arches which tolerates missing widget configs.