### PR TITLE
59 - Add graph slug and node alias as classes to all existing widgets

### DIFF
--- a/arches_component_lab/src/arches_component_lab/widgets/DateWidget/DateWidget.vue
+++ b/arches_component_lab/src/arches_component_lab/widgets/DateWidget/DateWidget.vue
@@ -60,18 +60,20 @@ onMounted(async () => {
             <span v-if="nodeData.isrequired && props.mode === EDIT">*</span>
         </label>
 
-        <DateWidgetEditor
-            v-if="props.mode === EDIT"
-            :initial-value="props.initialValue"
-            :graph-slug="props.graphSlug"
-            :node-alias="props.nodeAlias"
-            :widget-data="widgetData"
-        />
-        <DateWidgetViewer
-            v-else-if="props.mode === VIEW"
-            :initial-value="props.initialValue"
-            :widget-data="widgetData"
-        />
+        <div :class="[nodeAlias, graphSlug].join(' ')">
+            <DateWidgetEditor
+                v-if="mode === EDIT"
+                :initial-value="props.initialValue"
+                :graph-slug="props.graphSlug"
+                :node-alias="props.nodeAlias"
+                :widget-data="widgetData"
+            />
+            <DateWidgetViewer
+                v-else-if="mode === VIEW"
+                :initial-value="props.initialValue"
+                :widget-data="widgetData"
+            />
+        </div>
     </template>
     <Message
         v-if="configurationError"

--- a/arches_component_lab/src/arches_component_lab/widgets/FileListWidget/FileListWidget.vue
+++ b/arches_component_lab/src/arches_component_lab/widgets/FileListWidget/FileListWidget.vue
@@ -63,9 +63,10 @@ onMounted(async () => {
             <span v-if="nodeData.isrequired && props.mode === EDIT">*</span>
         </label>
 
-        <div v-if="mode === EDIT"></div>
-        <div v-if="mode === VIEW">
+        <div :class="[nodeAlias, graphSlug].join(' ')">
+            <div v-if="mode === EDIT"></div>
             <FileListWidgetViewer
+                v-else-if="mode === VIEW"
                 :value="initialValue"
                 :widget-data="widgetData"
             />

--- a/arches_component_lab/src/arches_component_lab/widgets/NonLocalizedStringWidget/NonLocalizedStringWidget.vue
+++ b/arches_component_lab/src/arches_component_lab/widgets/NonLocalizedStringWidget/NonLocalizedStringWidget.vue
@@ -59,16 +59,18 @@ onMounted(async () => {
             <span v-if="nodeData.isrequired && props.mode === EDIT">*</span>
         </label>
 
-        <NonLocalizedStringWidgetEditor
-            v-if="props.mode === EDIT"
-            :initial-value="initialValue"
-            :graph-slug="props.graphSlug"
-            :node-alias="props.nodeAlias"
-        />
-        <NonLocalizedStringWidgetViewer
-            v-else-if="props.mode === VIEW"
-            :value="props.initialValue"
-        />
+        <div :class="[nodeAlias, graphSlug].join(' ')">
+            <NonLocalizedStringWidgetEditor
+                v-if="mode === EDIT"
+                :initial-value="initialValue"
+                :graph-slug="props.graphSlug"
+                :node-alias="props.nodeAlias"
+            />
+            <NonLocalizedStringWidgetViewer
+                v-else-if="mode === VIEW"
+                :value="props.initialValue"
+            />
+        </div>
     </template>
     <Message
         v-if="configurationError"

--- a/arches_component_lab/src/arches_component_lab/widgets/ResourceInstanceMultiSelectWidget/ResourceInstanceMultiSelectWidget.vue
+++ b/arches_component_lab/src/arches_component_lab/widgets/ResourceInstanceMultiSelectWidget/ResourceInstanceMultiSelectWidget.vue
@@ -63,15 +63,17 @@ onMounted(async () => {
             <span v-if="nodeData.isrequired && props.mode === EDIT">*</span>
         </label>
 
-        <div v-if="mode === EDIT">
+        <div :class="[nodeAlias, graphSlug].join(' ')">
             <ResourceInstanceMultiSelectWidgetEditor
+                v-if="mode === EDIT"
                 :initial-value="initialValue"
                 :node-alias="props.nodeAlias"
                 :graph-slug="props.graphSlug"
             />
-        </div>
-        <div v-if="mode === VIEW">
-            <ResourceInstanceMultiSelectWidgetViewer :value="initialValue" />
+            <ResourceInstanceMultiSelectWidgetViewer
+                v-else-if="mode === VIEW"
+                :value="initialValue"
+            />
         </div>
         <Message
             v-if="configurationError"

--- a/arches_component_lab/src/arches_component_lab/widgets/ResourceInstanceSelectWidget/ResourceInstanceSelectWidget.vue
+++ b/arches_component_lab/src/arches_component_lab/widgets/ResourceInstanceSelectWidget/ResourceInstanceSelectWidget.vue
@@ -64,21 +64,18 @@ onMounted(async () => {
         </label>
 
         <div
-            v-if="mode === EDIT"
             :class="[props.nodeAlias, props.graphSlug].join(' ')"
         >
             <ResourceInstanceSelectWidgetEditor
+                v-if="mode === EDIT"
                 ref="editor"
                 :initial-value="initialValue"
                 :node-alias="props.nodeAlias"
                 :graph-slug="props.graphSlug"
             />
-        </div>
-        <div
-            v-if="mode === VIEW"
-            :class="[props.nodeAlias, props.graphSlug].join(' ')"
-        >
-            <ResourceInstanceSelectWidgetViewer :value="initialValue" />
+            <ResourceInstanceSelectWidgetViewer
+                v-else-if="mode === VIEW"
+                :value="initialValue" />
         </div>
         <Message
             v-if="configurationError"


### PR DESCRIPTION
Closes #59 
- Adds the graph slug and node alias as classes top level divs of all components to allow CSS targeting of specific node widgets.
