### PR TITLE
Cope with latest from querysets datatype standardization

### DIFF
--- a/arches_component_lab/src/arches_component_lab/widgets/ResourceInstanceMultiSelectWidget/components/ResourceInstanceMultiSelectWidgetEditor.vue
+++ b/arches_component_lab/src/arches_component_lab/widgets/ResourceInstanceMultiSelectWidget/components/ResourceInstanceMultiSelectWidgetEditor.vue
@@ -70,8 +70,6 @@ async function getOptions(page: number, filterTerm?: string) {
             ): ResourceInstanceReference => ({
                 display_value: resourceRecord.display_value,
                 resource_id: resourceRecord.resourceinstanceid,
-                ontologyProperty: "",
-                inverseOntologyProperty: "",
             }),
         );
 

--- a/arches_component_lab/src/arches_component_lab/widgets/ResourceInstanceMultiSelectWidget/components/ResourceInstanceMultiSelectWidgetEditor.vue
+++ b/arches_component_lab/src/arches_component_lab/widgets/ResourceInstanceMultiSelectWidget/components/ResourceInstanceMultiSelectWidgetEditor.vue
@@ -69,7 +69,7 @@ async function getOptions(page: number, filterTerm?: string) {
                 resourceRecord: ResourceInstanceResult,
             ): ResourceInstanceReference => ({
                 display_value: resourceRecord.display_value,
-                resourceId: resourceRecord.resourceinstanceid,
+                resource_id: resourceRecord.resourceinstanceid,
                 ontologyProperty: "",
                 inverseOntologyProperty: "",
             }),
@@ -123,7 +123,7 @@ async function onLazyLoadResources(event?: VirtualScrollerLazyEvent) {
 }
 
 function getOption(value: string): ResourceInstanceReference | undefined {
-    const option = options.value.find((option) => option.resourceId == value);
+    const option = options.value.find((option) => option.resource_id == value);
     return option;
 }
 
@@ -138,9 +138,11 @@ function resolver(e: FormFieldResolverOptions) {
 
     return {
         values: {
-            [props.nodeAlias]: options.value.filter((option) => {
-                return value?.includes(option.resourceId);
-            }),
+            [props.nodeAlias]: options.value
+                .filter((option) => {
+                    return value?.includes(option.resource_id);
+                })
+                .map((option) => option.resource_id),
         },
     };
 }
@@ -162,14 +164,14 @@ function validate(e: FormFieldResolverOptions) {
         v-slot="$field"
         :name="props.nodeAlias"
         :initial-value="
-            props.initialValue?.map((resource) => resource.resourceId)
+            props.initialValue?.map((resource) => resource.resource_id)
         "
         :resolver="resolver"
     >
         <MultiSelect
             display="chip"
             option-label="display_value"
-            option-value="resourceId"
+            option-value="resource_id"
             :filter="true"
             :filter-placeholder="$gettext('Filter Resources')"
             :fluid="true"

--- a/arches_component_lab/src/arches_component_lab/widgets/ResourceInstanceMultiSelectWidget/components/ResourceInstanceMultiSelectWidgetViewer.vue
+++ b/arches_component_lab/src/arches_component_lab/widgets/ResourceInstanceMultiSelectWidget/components/ResourceInstanceMultiSelectWidgetViewer.vue
@@ -9,10 +9,10 @@ const props = defineProps<{
 <template>
     <div
         v-for="resourceInstance in props.value"
-        :key="resourceInstance.resourceId"
+        :key="resourceInstance.resource_id"
     >
         <a
-            :href="`${arches.urls.resource_editor}${resourceInstance.resourceId}`"
+            :href="`${arches.urls.resource_editor}${resourceInstance.resource_id}`"
         >
             {{ resourceInstance.display_value }}
         </a>

--- a/arches_component_lab/src/arches_component_lab/widgets/ResourceInstanceSelectWidget/components/ResourceInstanceSelectWidgetEditor.vue
+++ b/arches_component_lab/src/arches_component_lab/widgets/ResourceInstanceSelectWidget/components/ResourceInstanceSelectWidgetEditor.vue
@@ -66,7 +66,7 @@ async function getOptions(page: number, filterTerm?: string) {
                 resourceRecord: ResourceInstanceResult,
             ): ResourceInstanceReference => ({
                 display_value: resourceRecord.display_value,
-                resourceId: resourceRecord.resourceinstanceid,
+                resource_id: resourceRecord.resourceinstanceid,
                 ontologyProperty: "",
                 inverseOntologyProperty: "",
             }),
@@ -127,7 +127,7 @@ function resolver(e: FormFieldResolverOptions) {
     return {
         values: {
             [props.nodeAlias]: options.value.find((option) => {
-                return value && value === option.resourceId;
+                return value && value === option.resource_id;
             }),
         },
     };
@@ -149,13 +149,13 @@ function validate(e: FormFieldResolverOptions) {
         v-else
         v-slot="$field"
         :name="props.nodeAlias"
-        :initial-value="props.initialValue?.resourceId"
+        :initial-value="props.initialValue?.resource_id"
         :resolver="resolver"
     >
         <Select
             display="chip"
             option-label="display_value"
-            option-value="resourceId"
+            option-value="resource_id"
             :filter="true"
             :filter-placeholder="$gettext('Filter Resources')"
             :fluid="true"

--- a/arches_component_lab/src/arches_component_lab/widgets/ResourceInstanceSelectWidget/components/ResourceInstanceSelectWidgetEditor.vue
+++ b/arches_component_lab/src/arches_component_lab/widgets/ResourceInstanceSelectWidget/components/ResourceInstanceSelectWidgetEditor.vue
@@ -67,8 +67,6 @@ async function getOptions(page: number, filterTerm?: string) {
             ): ResourceInstanceReference => ({
                 display_value: resourceRecord.display_value,
                 resource_id: resourceRecord.resourceinstanceid,
-                ontologyProperty: "",
-                inverseOntologyProperty: "",
             }),
         );
 

--- a/arches_component_lab/src/arches_component_lab/widgets/ResourceInstanceSelectWidget/components/ResourceInstanceSelectWidgetViewer.vue
+++ b/arches_component_lab/src/arches_component_lab/widgets/ResourceInstanceSelectWidget/components/ResourceInstanceSelectWidgetViewer.vue
@@ -7,8 +7,8 @@ const props = defineProps<{
 }>();
 </script>
 <template>
-    <div :key="props.value?.resourceId">
-        <a :href="`${arches.urls.resource_editor}${props.value?.resourceId}`">
+    <div :key="props.value?.resource_id">
+        <a :href="`${arches.urls.resource_editor}${props.value?.resource_id}`">
             {{ props.value?.display_value }}
         </a>
     </div>

--- a/arches_component_lab/src/arches_component_lab/widgets/api.ts
+++ b/arches_component_lab/src/arches_component_lab/widgets/api.ts
@@ -65,7 +65,7 @@ export const fetchRelatableResources = async (
         params.append("filter_term", filterTerm);
     }
     initialValues?.forEach((initialValue) =>
-        params.append("initialValue", initialValue.resourceId),
+        params.append("initialValue", initialValue.resource_id),
     );
     const response = await fetch(
         `${arches.urls.api_relatable_resources(

--- a/arches_component_lab/src/arches_component_lab/widgets/types.ts
+++ b/arches_component_lab/src/arches_component_lab/widgets/types.ts
@@ -13,7 +13,7 @@ export interface NewResourceInstance {
 }
 
 export interface ResourceInstanceReference {
-    resourceId: string;
+    resource_id: string;
     ontologyProperty: string;
     resourceXresourceId?: string;
     inverseOntologyProperty: string;

--- a/arches_component_lab/src/arches_component_lab/widgets/types.ts
+++ b/arches_component_lab/src/arches_component_lab/widgets/types.ts
@@ -14,10 +14,10 @@ export interface NewResourceInstance {
 
 export interface ResourceInstanceReference {
     resource_id: string;
-    ontologyProperty: string;
+    display_value: string;
+    ontologyProperty?: string;
     resourceXresourceId?: string;
-    inverseOntologyProperty: string;
-    display_value?: string;
+    inverseOntologyProperty?: string;
 }
 
 export interface ResourceInstanceResult {


### PR DESCRIPTION
re. archesproject/arches-querysets/pull/22

The backend now supplies `resource_id` rather than `resourceId`