### PR TITLE
Allow for null tile ids

### DIFF
--- a/arches_component_lab/src/arches_component_lab/cards/DefaultCard/DefaultCard.vue
+++ b/arches_component_lab/src/arches_component_lab/cards/DefaultCard/DefaultCard.vue
@@ -31,7 +31,7 @@ const props = defineProps<{
     mode: WidgetMode;
     nodegroupAlias: string;
     graphSlug: string;
-    tileId?: string;
+    tileId?: string | null;
 }>();
 
 const emit = defineEmits(["update:isDirty", "update:tileData"]);

--- a/arches_component_lab/src/arches_component_lab/cards/api.ts
+++ b/arches_component_lab/src/arches_component_lab/cards/api.ts
@@ -23,7 +23,7 @@ export const fetchCardData = async (
 export const fetchTileData = async (
     graphSlug: string,
     nodegroupAlias: string,
-    tileId: string | undefined,
+    tileId: string | null | undefined,
 ) => {
     const response = await fetch(
         arches.urls.api_tile(graphSlug, nodegroupAlias, tileId),


### PR DESCRIPTION
Fixes ts lint on main of arches-modular-report, where blank unsaved tiles generated server-side can be null.