### PR TITLE
Prevent calling tile api with null tile pk

### DIFF
--- a/arches_component_lab/src/arches_component_lab/cards/DefaultCard/DefaultCard.vue
+++ b/arches_component_lab/src/arches_component_lab/cards/DefaultCard/DefaultCard.vue
@@ -84,15 +84,17 @@ watchEffect(async () => {
                 props.graphSlug,
                 props.nodegroupAlias,
             );
-        const tileDataPromise = fetchTileData(
-            props.graphSlug,
-            props.nodegroupAlias,
-            props.tileId,
-        );
+        if (props.tileId) {
+            const tileDataPromise = fetchTileData(
+                props.graphSlug,
+                props.nodegroupAlias,
+                props.tileId,
+            );
+            tileData.value = await tileDataPromise;
+        }
 
         cardData.value = await cardDataPromise;
         cardXNodeXWidgetData.value = await cardXNodeXWidgetDataPromise;
-        tileData.value = await tileDataPromise;
     } catch (error) {
         configurationError.value = error;
     } finally {

--- a/arches_component_lab/src/arches_component_lab/cards/DefaultCard/DefaultCard.vue
+++ b/arches_component_lab/src/arches_component_lab/cards/DefaultCard/DefaultCard.vue
@@ -84,7 +84,7 @@ watchEffect(async () => {
                 props.graphSlug,
                 props.nodegroupAlias,
             );
-        if (props.tileId && props.tileId !== "root") {
+        if (props.tileId) {
             const tileDataPromise = fetchTileData(
                 props.graphSlug,
                 props.nodegroupAlias,

--- a/arches_component_lab/src/arches_component_lab/cards/DefaultCard/DefaultCard.vue
+++ b/arches_component_lab/src/arches_component_lab/cards/DefaultCard/DefaultCard.vue
@@ -84,7 +84,7 @@ watchEffect(async () => {
                 props.graphSlug,
                 props.nodegroupAlias,
             );
-        if (props.tileId) {
+        if (props.tileId && props.tileId !== "root") {
             const tileDataPromise = fetchTileData(
                 props.graphSlug,
                 props.nodegroupAlias,

--- a/arches_component_lab/urls.py
+++ b/arches_component_lab/urls.py
@@ -40,12 +40,12 @@ urlpatterns = [
         name="api-node-data",
     ),
     path(
-        "arches-component-lab/api/card-x-node-x-widget-list-from-nodegroup/<slug:graph_slug>/<slug:nodegroup_grouping_node_alias>",
+        "arches-component-lab/api/card-x-node-x-widget-list-from-nodegroup/<slug:graph_slug>/<slug:nodegroup_alias>",
         CardXNodeXWidgetListFromNodegroupView.as_view(),
         name="api-card-x-node-x-widget-list-from-nodegroup",
     ),
     path(
-        "arches-component-lab/api/card-data/<slug:graph_slug>/<slug:nodegroup_grouping_node_alias>",
+        "arches-component-lab/api/card-data/<slug:graph_slug>/<slug:nodegroup_alias>",
         CardDataView.as_view(),
         name="api-card-data",
     ),

--- a/arches_component_lab/views/api/card.py
+++ b/arches_component_lab/views/api/card.py
@@ -7,15 +7,15 @@ from arches.app.utils.response import JSONResponse
 
 
 class CardDataView(View):
-    def get(self, request, graph_slug, nodegroup_grouping_node_alias):
+    def get(self, request, graph_slug, nodegroup_alias):
 
         if arches_version < (8, 0):
             card = models.CardModel.objects.filter(
                 graph__slug=graph_slug,
-                nodegroup__node__alias=nodegroup_grouping_node_alias,
+                nodegroup__node__alias=nodegroup_alias,
             ).get()
         else:
-            node = models.Node.objects.get(alias=nodegroup_grouping_node_alias)
+            node = models.Node.objects.get(alias=nodegroup_alias)
             card = models.CardModel.objects.get(
                 graph__slug=graph_slug,
                 nodegroup_id=node.nodegroup_id,

--- a/arches_component_lab/views/api/card_x_node_x_widget.py
+++ b/arches_component_lab/views/api/card_x_node_x_widget.py
@@ -75,10 +75,10 @@ class CardXNodeXWidgetView(View):
 
 
 class CardXNodeXWidgetListFromNodegroupView(View):
-    def get(self, request, graph_slug, nodegroup_grouping_node_alias):
+    def get(self, request, graph_slug, nodegroup_alias):
         card_x_node_x_widgets_query = Q(
             node__graph__slug=graph_slug,
-            node__nodegroup__node__alias=nodegroup_grouping_node_alias,
+            node__nodegroup__node__alias=nodegroup_alias,
         )
 
         if arches_version >= (8, 0):


### PR DESCRIPTION
Closes archesproject/arches-modular-reports#24

Eventually we'll want to ensure we actually get the default values populated, but the tree already has that, and we're about to iterate on tree <--> form communication. So just fix the crash for now.