### PR TITLE
Increment version after alpha2 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "arches>=7.6.9",
     "arches_querysets[drf] @ git+https://github.com/archesproject/arches-querysets@main",
 ]
-version = "0.0.1a0"
+version = "0.0.1a2"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
The version number on main wasn't incremented after the a2 release. This led to pip failures like:


```
INFO: pip is looking at multiple versions of arches-modular-reports to determine which version is compatible with other requirements. This could take a while.
ERROR: Cannot install casf-database because these package versions have conflicting dependencies.

The conflict is caused by:
    arches-controlled-lists 1.0.0b1 depends on arches-component-lab 0.0.1a0 (from git+https://github.com/archesproject/arches-component-lab.git@main)
```