### PR TITLE
adds number widget to address #68

### DIFF
--- a/arches_component_lab/src/arches_component_lab/datatypes/number/types.ts
+++ b/arches_component_lab/src/arches_component_lab/datatypes/number/types.ts
@@ -1,0 +1,19 @@
+import type { AliasedNodeData } from "@/arches_component_lab/types.ts";
+import type { CardXNodeXWidgetData } From "@/arches_component_lab/types.ts";
+
+export interface NumberCardXNodeXWidgetData extends CardXNodeXWidgetData {
+    config: CardXNodeXWidgetData["config"] & {
+        prefix?: string;   
+        suffix?: string;
+        min?: number;
+        max?: number;
+        step?: number;
+        precision?: string | number;
+    };
+}
+
+export interface NumberValue extends AliasedNodeData {
+    display_value: number;
+    node_value: number;
+    details: [];
+}

--- a/arches_component_lab/src/arches_component_lab/widgets/NumberWidget/NumberWidget.vue
+++ b/arches_component_lab/src/arches_component_lab/widgets/NumberWidget/NumberWidget.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import NumberWidgetEditor from "@/arches_component_lab/widgets/NumberWidget/components/NumberWidgetEditor.vue";
+import NumberWidgetViewer from "@/arches_component_lab/widgets/NumberWidget/components/NumberWidgetViewer.vue";
+
+import { EDIT, VIEW } from "@/arches_component_lab/widgets/constants.ts";
+
+import type { CardXNodeXWidgetData } from "@/arches_component_lab/types.ts";
+import type { NumberValue } from "@/arches_component_lab/datatypes/number/types.ts";
+import type { WidgetMode } from "@/arches_component_lab/widgets/types.ts";
+
+defineProps<{
+    mode: WidgetMode;
+    nodeAlias: string;
+    graphSlug: string;
+    cardXNodeXWidgetData: CardXNodeXWidgetData;
+    aliasedNodeData: NumberValue;
+}>();
+
+const emit = defineEmits(["update:isDirty", "update:value"]);
+</script>
+
+<template>
+    <NumberWidgetEditor
+        v-if="mode === EDIT"
+        :card-x-node-x-widget-data="cardXNodeXWidgetData"
+        :graph-slug="graphSlug"
+        :node-alias="nodeAlias"
+        :aliased-node-data="aliasedNodeData"
+        @update:value="emit('update:value', $event)"
+        @update:is-dirty="emit('update:isDirty', $event)"
+    />
+    <NumberWidgetViewer
+        v-if="mode === VIEW"
+        :card-x-node-x-widget-data="cardXNodeXWidgetData"
+        :aliased-node-data="aliasedNodeData"
+    />
+</template>

--- a/arches_component_lab/src/arches_component_lab/widgets/NumberWidget/components/NumberWidgetEditor.vue
+++ b/arches_component_lab/src/arches_component_lab/widgets/NumberWidget/components/NumberWidgetEditor.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import InputNumber from 'primevue/inputnumber';
+
+import type { NumberCardXNodeXWidgetData, NumberValue } from "@/arches_component_lab/datatypes/number/types.ts";
+
+const { cardXNodeXWidgetData, aliasedNodeData } = defineProps<{
+  cardXNodeXWidgetData: NumberCardXNodeXWidgetData;
+  aliasedNodeData: NumberValue;
+}>();
+
+const emit = defineEmits<{
+  (event: "update:value", updatedValue: NumberValue): void;
+}>();
+
+function onUpdateModelValue(updatedValue: number | null) {
+    emit("update:value", {
+        display_value: updatedValue ?? null,
+        node_value: updatedValue ?? null,
+        details: [],
+    });
+}
+</script>
+
+<template>
+    <InputNumber 
+        :model-value="aliasedNodeData?.node_value ?? null"
+        :fluid="true"
+        :inputId="cardXNodeXWidgetData.node.alias"
+        :placeholder="cardXNodeXWidgetData.config.placeholder"
+        :prefix="cardXNodeXWidgetData.config.prefix ?? ''"
+        :suffix="cardXNodeXWidgetData.config.suffix ?? ''"
+        :minFractionDigits="+cardXNodeXWidgetData.config.precision || 0"
+        :maxFractionDigits="+cardXNodeXWidgetData.config.precision || 0"
+        :min="cardXNodeXWidgetData.config.min"
+        :max="cardXNodeXWidgetData.config.max"
+        @update:model-value="onUpdateModelValue($event)"
+    />
+    <pre>{{ cardXNodeXWidgetData.config }}</pre>
+</template>

--- a/arches_component_lab/src/arches_component_lab/widgets/NumberWidget/components/NumberWidgetViewer.vue
+++ b/arches_component_lab/src/arches_component_lab/widgets/NumberWidget/components/NumberWidgetViewer.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+import type { 
+    NumberValue,
+    NumberCardXNodeXWidgetData
+ } from "@/arches_component_lab/datatypes/number/types";
+
+const { aliasedNodeData, cardXNodeXWidgetData } = defineProps<{
+    aliasedNodeData: NumberValue | undefined;
+    cardXNodeXWidgetData: NumberCardXNodeXWidgetData;
+}>();
+</script>
+
+<template>
+    <div>{{ aliasedNodeData.display_value }}</div>
+</template>


### PR DESCRIPTION
should the config of the number (i.e. adding prefix or setting decimals) be visible when `v-if="mode === VIEW"`? If so, would like to have a discussion about where that happens