### PR TITLE
Add optional chaining operator to ResourceInstanceSelectWidgetViewer

### DIFF
--- a/arches_component_lab/src/arches_component_lab/widgets/ResourceInstanceSelectWidget/components/ResourceInstanceSelectWidgetViewer.vue
+++ b/arches_component_lab/src/arches_component_lab/widgets/ResourceInstanceSelectWidget/components/ResourceInstanceSelectWidgetViewer.vue
@@ -8,11 +8,11 @@ defineProps<{
 }>();
 </script>
 <template>
-    <div :key="aliasedNodeData?.details[0].resource_id">
+    <div :key="aliasedNodeData?.details?.[0]?.resource_id">
         <a
-            :href="`${arches.urls.resource_editor}${aliasedNodeData?.details[0].resource_id}`"
+            :href="`${arches.urls.resource_editor}${aliasedNodeData?.details?.[0]?.resource_id}`"
         >
-            {{ aliasedNodeData?.details[0].display_value }}
+            {{ aliasedNodeData?.details?.[0]?.display_value }}
         </a>
     </div>
 </template>


### PR DESCRIPTION
Protect against undefined intermediate attributes to avoid `undefined` errors when passed an empty aliased node data object.

closes #157