### PR TITLE
Generic widget should allow partial config override

### DIFF
--- a/arches_component_lab/src/arches_component_lab/generics/GenericWidget/GenericWidget.vue
+++ b/arches_component_lab/src/arches_component_lab/generics/GenericWidget/GenericWidget.vue
@@ -35,7 +35,7 @@ const {
     shouldEmitSimplifiedValue = false,
 } = defineProps<{
     cardXNodeXWidgetData?: CardXNodeXWidgetData;
-    cardXNodeXWidgetDataOverrides?: CardXNodeXWidgetData;
+    cardXNodeXWidgetDataOverrides?: Partial<CardXNodeXWidgetData>;
     graphSlug: string;
     isDirty?: boolean;
     mode: WidgetMode;


### PR DESCRIPTION
Widget user should be able to override parts of the cardXNodeXWidgetData, not be required to override the whole configuration.