### PR TITLE
Fixes regression where version number was lost in the PR name

### DIFF
--- a/.github/scripts/release_prep.py
+++ b/.github/scripts/release_prep.py
@@ -16,9 +16,6 @@ def get_latest_published_version(package: str) -> Version:
 
 
 def increment_version(current: Version, branch: str) -> str:
-    if "test" in branch:
-        branch = "release_alpha"
-
     if not current:
         current = Version(f"0.0.0")
 

--- a/.github/workflows/release_prep.yml
+++ b/.github/workflows/release_prep.yml
@@ -8,7 +8,6 @@ on:
       - 'release_patch'
       - 'release_minor'
       - 'release_major'
-      - 'test/*'
 
 permissions:
   contents: write


### PR DESCRIPTION
Re-adds the new version number to PR titles like the top one here:
<img width="476" height="216" alt="image" src="https://github.com/user-attachments/assets/62906347-3732-4229-8cd3-aac07a724105" />
