### PR TITLE
Use date format from node config

### DIFF
--- a/arches_component_lab/src/arches_component_lab/widgets/DatePickerWidget/components/DatePickerWidgetEditor.vue
+++ b/arches_component_lab/src/arches_component_lab/widgets/DatePickerWidget/components/DatePickerWidgetEditor.vue
@@ -65,7 +65,7 @@ function onUpdateModelValue(updatedValue: string) {
 
             formValue = {
                 display_value: formattedDate,
-                node_value: date.toISOString(),
+                node_value: formattedDate,
                 details: [],
             };
         } catch (_error) {


### PR DESCRIPTION
Uses the formatted date not full ISO datetime string as `node_value` to align with current arches date widget implementation.