### PR TITLE
Move hard-coded pt styling to CSS styles in Text & Rich Text editors

### DIFF
--- a/arches_component_lab/src/arches_component_lab/widgets/RichTextWidget/components/RichTextWidgetEditor/RichTextWidgetEditor.vue
+++ b/arches_component_lab/src/arches_component_lab/widgets/RichTextWidget/components/RichTextWidgetEditor/RichTextWidgetEditor.vue
@@ -123,7 +123,9 @@ function onUpdateModelValue(updatedValue: string | undefined) {
 </template>
 
 <style>
-.p-select-options, .p-select-label, .p-select-overlay {
+.p-select-options,
+.p-select-label,
+.p-select-overlay {
     font-size: 1rem;
 }
 </style>

--- a/arches_component_lab/src/arches_component_lab/widgets/TextWidget/components/TextWidgetEditor.vue
+++ b/arches_component_lab/src/arches_component_lab/widgets/TextWidget/components/TextWidgetEditor.vue
@@ -115,7 +115,9 @@ function onUpdateModelValue(updatedValue: string | undefined) {
 </template>
 
 <style>
-.p-select-options, .p-select-label, .p-select-overlay {
+.p-select-options,
+.p-select-label,
+.p-select-overlay {
     font-size: 1rem;
 }
 </style>


### PR DESCRIPTION
Interim fix to allow widget users to override Text & Rich Text language dropdown font sizes.