### PR TITLE
Fix edge case when file is stored in local browser storage

### DIFF
--- a/arches_component_lab/src/arches_component_lab/widgets/FileListWidget/components/FileListWidgetViewer.vue
+++ b/arches_component_lab/src/arches_component_lab/widgets/FileListWidget/components/FileListWidgetViewer.vue
@@ -13,11 +13,10 @@ const props = defineProps<{
 }>();
 
 const getFileUrl = (originalUrl: string) => {
+    const httpRegex = /^(blob|https?):\/\//;
     if (
         !originalUrl ||
-        originalUrl.toLowerCase().startsWith("http://") ||
-        originalUrl.toLowerCase().startsWith("https://") ||
-        originalUrl.toLowerCase().startsWith("blob:") ||
+        httpRegex.test(originalUrl) ||
         originalUrl.startsWith(arches.urls.url_subpath)
     ) {
         return originalUrl;


### PR DESCRIPTION
When the file is in local storage, the URL starts with "blob:". This is a follow-up to PR #244. 